### PR TITLE
docs(usage_docs): added brief docs on how to setup the project locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,12 @@ Brahmos Library: [https://github.com/s-yadav/brahmos](https://github.com/s-yadav
 See demo on
 [Live: brahmos-todo-mvc](https://s-yadav.github.io/brahmos-todo-mvc)
 
+
+## Usage Instructions
+
+1. Download [yarn](https://yarnpkg.com/lang/en/docs/install/) if you don't have it.
+1. Install project dependencies with `yarn install`.
+1. Start the dev server with `yarn start`.
+1. WebApp will open on http://localhost:8085.
+
 Fork of [React todoMVC](https://github.com/ChrisWiles/React-todoMVC) by ChrisWiles.


### PR DESCRIPTION
Some people might try to use npm and would generate package-lock.json file and then if that file is gone in PR, you have to review it and flag it out. So the person will have to repeat the install with yarn. To prevent this adding clear instructions in the readme would be better, I think.